### PR TITLE
Bump Laravel dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=7.2.5",
     "area17/twill": "2.*|3.*",
-    "laravel/framework": "~5.6|~5.7|~5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+    "laravel/framework": "~5.6|~5.7|~5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
     "spatie/laravel-view-models": "^1.3"
   },
   "config": {


### PR DESCRIPTION
This only bumps the Laravel dependency. I haven't thoroughly checked it or run any tests. I don't see anything in the code that lines up with the small handful of potentially breaking changes from Laravel 11 to 12.